### PR TITLE
Clarified some points for non-Linux users based on feedback during WRK3007

### DIFF
--- a/100.md
+++ b/100.md
@@ -82,7 +82,7 @@ The purpose of this Hands on Lab (HOL) is to have an understanding of how to:
     sudo docker build -t starterapp:latest . 
     
     # Run docker images to see your image listed. Make a note of the IMAGE ID for your built image
-    docker images
+    sudo docker images
     
     # Sample output:
     REPOSITORY                                         TAG                 IMAGE ID                         CREATED             SIZE 
@@ -96,11 +96,11 @@ The purpose of this Hands on Lab (HOL) is to have an understanding of how to:
     # Enter your credentials to login to docker hub.
     
     # Now tag the locally built image to Docker Hub repo. 
-    docker tag <your_image_id> <your-docker-user-name>/starterapp:latest
+    sudo docker tag <your_image_id> <your-docker-user-name>/starterapp:latest
     
     Now push the image to Docker Hub
     
-    docker push  <your-docker-user-name>/starterapp:latest                             
+    sudo docker push  <your-docker-user-name>/starterapp:latest                             
     
     # You should see the repo created in your Docker Hub page 
 
@@ -148,7 +148,7 @@ The purpose of this Hands on Lab (HOL) is to have an understanding of how to:
 
     # You can obtain the Webhook URL 
      
-    az webapp deployment container show-cd-url -n sname1 -g rgname
+    az webapp deployment container show-cd-url -n <your_app_name> -g myResourceGroup
 
     # For the Webhook URL, you need to have the following endpoint: 
     


### PR DESCRIPTION

Included missing sudo commands
Swapped the use of `sname` for `<your_app_name>` and `rname` for `myResourceGroup` to bring them into line with earlier command examples